### PR TITLE
Close the panel before presenting the install terminal

### DIFF
--- a/Panel.qml
+++ b/Panel.qml
@@ -1305,6 +1305,12 @@ Panel {
       }
       installerProcess.command = Model.installProcessArgs()
       installerProcess.startDetached()
+      // The installer runs in Omarchy's presented terminal, where sudo asks
+      // for the user's password. While the panel is open its full-screen
+      // overlay holds the shell's keyboard focus, so the panel must close
+      // before that terminal can receive any typing. The install poll keeps
+      // running with the panel closed and settles the state for reopening.
+      root.close()
       installPoll.restart()
       installTimeout.restart()
     }

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ systemctl --user restart hyprmoncfgd.service
 setsid -f gtk-launch hyprmoncfg-omarchy >/dev/null 2>&1
 ```
 
-The installer uses Omarchy's install helper when the package is missing and upgrades an existing package directly through `yay`. Both commands run in Omarchy's presented terminal, never invisibly inside `omarchy-shell`. After a successful install or upgrade it explicitly restarts the daemon, so an already-running service immediately uses the new binary, then opens hyprmoncfg through its hidden Omarchy desktop launcher. That launcher ships with the main package and carries Omarchy's standard `TUI.float` window identity, so the editor opens centered at the normal floating size without putting Omarchy-specific window logic in the panel. Saving a profile updates the panel immediately over IPC.
+The installer uses Omarchy's install helper when the package is missing and upgrades an existing package directly through `yay`. Both commands run in Omarchy's presented terminal, never invisibly inside `omarchy-shell`. The panel closes itself as that terminal opens: while open it is a full-screen overlay that holds the shell's keyboard focus, and `sudo`'s password prompt in the terminal would never receive what you type. After a successful install or upgrade it explicitly restarts the daemon, so an already-running service immediately uses the new binary, then opens hyprmoncfg through its hidden Omarchy desktop launcher. That launcher ships with the main package and carries Omarchy's standard `TUI.float` window identity, so the editor opens centered at the normal floating size without putting Omarchy-specific window logic in the panel. Saving a profile updates the panel immediately over IPC.
 
 ## Requirements
 


### PR DESCRIPTION
## The problem

Clicking **Install hyprmoncfg** repeatedly fails with the presented terminal stuck asking for the password. Symptoms on an Omarchy 4.0.1 machine (Arch, Hyprland):

- The floating terminal opens, `yay` builds the package fine, then `[sudo] password for diceman:` appears — but nothing typed ever reaches it.
- The journal shows the stalled `sudo` processes dying with `pam_unix(sudo:auth): conversation failed` / `auth could not identify password` (EOF at the prompt) when the terminals are closed — and no `authentication failure` entries, i.e. no password ever arrived.
- Every retry opens another terminal that asks for the password again; `~/.cache/yay/hyprmoncfg` ends up with a built package that pacman never installed.

## The cause

`install()` leaves the panel open while the presented terminal runs. The panel's host — Omarchy's `KeyboardPanel` — is a full-screen layer-shell surface on the **overlay layer** that holds the shell's keyboard focus while open (`WlrLayershell.keyboardFocus` primed Exclusive, then OnDemand). The terminal opens under that overlay and never receives keystrokes, so the sudo prompt can't be answered. Typing the password actually feeds the panel's single-letter hotkeys instead.

Reproduced the script itself in a plain pty: it runs cleanly up to the sudo prompt and accepts input there, so the failure is specific to the panel holding focus, not to the install command.

## The fix

Close the panel as the installer terminal launches — the same thing `launchTui()` already does, and the same order Omarchy's own menu uses (`opened = false` / `cancel()` before `runAction`). `installPoll`/`installTimeout` run on `root.installing`, not on the panel being open, so completion is still detected and the panel state is settled when it is reopened.

`omarchy plugin validate .` passes and `node --test tests/model.test.js` is 47/47.